### PR TITLE
Use `OrderedDict` in `to_qe` method for `Namelist`s

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Qi Zhang <singularitti@outlook.com>"]
 version = "0.1.0"
 
 [deps]
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 FilePaths = "8fc22ac5-c921-52a6-82fd-178b2807b824"
 Fortran90Namelists = "8fb689aa-71ff-4044-8071-0cffc910b57d"
 IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"

--- a/src/Namelists/Namelists.jl
+++ b/src/Namelists/Namelists.jl
@@ -18,7 +18,7 @@ using FilePaths: AbstractPath, extension, exists
 using Fortran90Namelists.JuliaToFortran: to_fortran
 import JSON
 using MLStyle: @match
-using Parameters: type2dict
+using DataStructures: OrderedDict
 
 using QuantumESPRESSOBase: InputEntry
 
@@ -28,8 +28,12 @@ export Namelist, to_dict, dropdefault
 
 abstract type Namelist <: InputEntry end
 
-function to_dict(nml::Namelist)::Dict{Symbol,Any}
-    return type2dict(nml)
+function to_dict(nml::Namelist; keeporder::Bool = true)
+    dict = (keeporder ? OrderedDict{Symbol,Any}() : Dict{Symbol,Any}())
+    for n in propertynames(nml)
+        dict[n] = getproperty(nml, n)
+    end
+    return dict
 end
 
 function dropdefault(nml::Namelist)

--- a/src/Namelists/Namelists.jl
+++ b/src/Namelists/Namelists.jl
@@ -29,16 +29,16 @@ export Namelist, to_dict, dropdefault
 abstract type Namelist <: InputEntry end
 
 """
-    to_dict(nml; keeporder = true)
+    to_dict(nml; defaultorder = true)
 
 Convert a `Namelist` to a dictionary.
 
 # Arguments
 - `nml::Namelist`: the namelist to be converted.
-- `keeporder::Bool = true`: whether or not use the default order of parameters in QE's docs.
+- `defaultorder::Bool = true`: whether or not use the default order of parameters in QE's docs.
 """
-function to_dict(nml::Namelist; keeporder::Bool = true)
-    dict = (keeporder ? OrderedDict{Symbol,Any}() : Dict{Symbol,Any}())
+function to_dict(nml::Namelist; defaultorder::Bool = true)
+    dict = (defaultorder ? OrderedDict{Symbol,Any}() : Dict{Symbol,Any}())
     for n in propertynames(nml)
         dict[n] = getproperty(nml, n)
     end

--- a/src/Namelists/Namelists.jl
+++ b/src/Namelists/Namelists.jl
@@ -28,6 +28,15 @@ export Namelist, to_dict, dropdefault
 
 abstract type Namelist <: InputEntry end
 
+"""
+    to_dict(nml; keeporder = true)
+
+Convert a `Namelist` to a dictionary.
+
+# Arguments
+- `nml::Namelist`: the namelist to be converted.
+- `keeporder::Bool = true`: whether or not use the default order of parameters in QE's docs.
+"""
 function to_dict(nml::Namelist; keeporder::Bool = true)
     dict = (keeporder ? OrderedDict{Symbol,Any}() : Dict{Symbol,Any}())
     for n in propertynames(nml)


### PR DESCRIPTION
In the past, the order was not kept when converting a `PWscf` object to a `Dict`. Now it can use the order specified in QE's doc.