### PR TITLE
No need to call `Pkg.update()` before you add a package

### DIFF
--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -58,7 +58,7 @@ platform to explain the following steps:
 2. Run the following commands and wait for them to finish:
 
    ```julia
-   julia> using Pkg; Pkg.update()
+   julia> using Pkg
 
    julia> Pkg.add("QuantumESPRESSOBase")
    ```
@@ -77,7 +77,7 @@ platform to explain the following steps:
 If you want to install the latest in development (maybe buggy) version of `QuantumESPRESSOBase`, type
 
 ```julia
-julia> using Pkg; Pkg.update()
+julia> using Pkg
 
 julia> pkg"add QuantumESPRESSOBase#master"
 ```


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Docs: update installation instructions.


* **What is the current behavior?** (You can also link to an open issue here)

Docs suggest that one needs to update all packages before adding QuantumESPRESSOBase

* **What is the new behavior (if this is a feature change)?**

Drops the `Pkg.update()`.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Nope

* **Other information**:
