### PR TITLE
Make all `Card`'s options to be `Symbol`s, not `String`s

### DIFF
--- a/ext/CrystallographyExt.jl
+++ b/ext/CrystallographyExt.jl
@@ -12,15 +12,15 @@ function getsymmetry(input::PWInput, symprec=1e-5)
     data = Iterators.map(input.atomic_positions.data) do atomic_position
         atom, position = atomic_position.atom, atomic_position.pos
         # `position` is a `Vector` in unit of "bohr"
-        if option == "alat"
+        if option == :alat
             position *= input.system.celldm[1]
-        elseif option == "bohr"
+        elseif option == :bohr
             position
-        elseif option == "angstrom"
+        elseif option == :angstrom
             ustrip.(u"bohr", position * u"angstrom")
-        elseif option == "crystal"
+        elseif option == :crystal
             lattice(position)
-        else  # option == "crystal_sg"
+        else  # option == :crystal_sg
             error("unimplemented!")  # FIXME
         end
         position, atom

--- a/src/CP/CP.jl
+++ b/src/CP/CP.jl
@@ -165,11 +165,11 @@ Return the cell volume of a `CellParametersCard` or `RefCellParametersCard`, in 
 """
 function cellvolume(card::AbstractCellParametersCard)
     option = optionof(card)
-    if option == "bohr"
+    if option == :bohr
         abs(det(card.data))
-    elseif option == "angstrom"
+    elseif option == :angstrom
         ustrip(u"bohr^3", abs(det(card.data)) * u"angstrom^3")
-    else  # option == "alat"
+    else  # option == :alat
         error("information not enough! Parameter `celldm[1]` needed!")
     end
 end # function cellvolume

--- a/src/PWscf/crystallography.jl
+++ b/src/PWscf/crystallography.jl
@@ -21,11 +21,11 @@ Create a `Lattice` from a `CellParametersCard`.
 """
 function Lattice(card::CellParametersCard)
     m, option = transpose(card.data), getoption(card)
-    if option == "alat"
+    if option == :alat
         throw(InsufficientInfoError("parameter `celldm[1]` needed!"))
-    elseif option == "bohr"
+    elseif option == :bohr
         return Lattice(m)
-    else  # option == "angstrom"
+    else  # option == :angstrom
         return Lattice(m * ustrip(u"bohr", 1u"angstrom"))
     end
 end
@@ -65,11 +65,11 @@ Return the cell volume of a `CellParametersCard` or `RefCellParametersCard`, in 
 """
 function cellvolume(card::AbstractCellParametersCard)
     option = getoption(card)
-    if option == "bohr"
+    if option == :bohr
         return abs(det(card.data))
-    elseif option == "angstrom"
+    elseif option == :angstrom
         return ustrip(u"bohr^3", abs(det(card.data)) * u"angstrom^3")
-    else  # option == "alat"
+    else  # option == :alat
         throw(InsufficientInfoError("parameter `celldm[1]` needed!"))
     end
 end

--- a/test/CP.jl
+++ b/test/CP.jl
@@ -99,7 +99,7 @@ end # testset
         4 3 2 1
         8 7 6 5
     ]
-    @test RefCellParametersCard(data).option == "bohr"
+    @test RefCellParametersCard(data).option == :bohr
 end # testset
 
 end # module CP

--- a/test/PWscf.jl
+++ b/test/PWscf.jl
@@ -103,7 +103,7 @@ end
         4 3 2 1
         8 7 6 5
     ]
-    @test CellParametersCard(data).option == "alat" # default option is alat
+    @test CellParametersCard(data).option == :alat # default option is alat
 end
 
 @testset "Construct `AtomicForce`" begin


### PR DESCRIPTION
Because we could dispatch on `Val{:S}`